### PR TITLE
Added accepted delay for received messages.

### DIFF
--- a/plugins/echo.py
+++ b/plugins/echo.py
@@ -8,5 +8,8 @@ class EchoPlugin(plugin.TelexPlugin):
     def test_callback(self, count, text, *, bot, msg):
         if not count:
             count = 1
-        for i in range(0,int(count)):
-            self.respond_to_msg(msg, text)
+        if count > 20:
+            self.respond_to_msg(msg, "Maximum count is 20")
+        else
+            for i in range(0,int(count)):
+                self.respond_to_msg(msg, text)

--- a/telex.conf.example
+++ b/telex.conf.example
@@ -1,2 +1,3 @@
 [Global]
 command_prefix = !
+accepted_delay = 30

--- a/telex/callbacks/msgreceived.py
+++ b/telex/callbacks/msgreceived.py
@@ -1,6 +1,6 @@
+import re
 from enum import Enum
 from functools import wraps
-
 from .callback import callback, MSG_RECEIVED
 
 def msg_received(func):

--- a/telex/telexbot.py
+++ b/telex/telexbot.py
@@ -73,8 +73,6 @@ class TelexBot:
             return
         if(msg.date <= datetime.now()-timedelta(seconds=self.accepted_delay)):
             return
-        if msg.text == None:
-            return
         
         peer = self.get_peer_to_send(msg)
 

--- a/telex/telexbot.py
+++ b/telex/telexbot.py
@@ -1,6 +1,7 @@
 import tgl
 
 import re
+from datetime import datetime, timedelta
 from configparser import ConfigParser
 from .TelexPluginManager import TelexPluginManager
 
@@ -18,6 +19,10 @@ class TelexBot:
             self.pfx = self.config['Global']['command_prefix']
         except KeyError:
             self.pfx = "!"
+        try:
+            self.accepted_delay = self.config['Global']['accepted_delay']
+        except KeyError:
+            self.accepted_delay = 30        #in secs
 
     # Util
     def admin_check(self, msg):
@@ -66,7 +71,11 @@ class TelexBot:
         from telex.callbacks.callback import MSG_RECEIVED
         if msg.out or not self.binlog_done:
             return
-
+        if(msg.date <= datetime.now()-timedelta(seconds=self.accepted_delay)):
+            return
+        if msg.text == None:
+            return
+        
         peer = self.get_peer_to_send(msg)
 
         # new callback WIP


### PR DESCRIPTION
If bot is offline and comes online, it will respond only to messages sent in last <accepted_delay> seconds.
By default, this value is 30 secs and can be configured from telex.conf
